### PR TITLE
mirrorPlotRACER(): Fix assoc name 2 for missing LD

### DIFF
--- a/R/mirrorPlotRACER.R
+++ b/R/mirrorPlotRACER.R
@@ -200,7 +200,7 @@ mirrorPlotRACER <- function(assoc_data1, assoc_data2, chr, build = "hg19", set =
         ggplot2::xlim(start,end) + ggplot2::ylim(min(in.dt.2$LOG10P),max(in.dt.2$LOG10P)) +
         ggplot2::theme(axis.title.x=ggplot2::element_blank(),
                        axis.text.x=ggplot2::element_blank(),
-                       axis.ticks.x=ggplot2::element_blank()) + ggplot2::ggtitle(paste0(name1)) +
+                       axis.ticks.x=ggplot2::element_blank()) + ggplot2::ggtitle(paste0(name2)) +
         theme(plot.title = element_text(size = 10, vjust = -1))
   }
 


### PR DESCRIPTION
Hi,

I tried to use mirrorPlotRACER without LD information, and found that the name for association plot #2 is ignored. Here is a small patch to fix that,

Kind regards,
Lennart